### PR TITLE
Feature - Build System Overhaul

### DIFF
--- a/AetherEngine/CMakeLists.txt
+++ b/AetherEngine/CMakeLists.txt
@@ -35,7 +35,21 @@ option(USE_VULKAN "Build with Vulkan" OFF)
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
+# Set a unified folder for runtime binaries (DLLs, EXEs, PDBs)
+set(BIN_DIR ${CMAKE_BINARY_DIR}/bin)
 
-# Add main projects as indivudual subdirectories as they have their own CMakeLists file
+# All targets (DLL/EXE) will output here
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BIN_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${BIN_DIR})
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${BIN_DIR})  # For static libs from third-parties
+
+# Ensure multi-config support (Debug/Release)
+foreach(OUTPUT_CONFIG Debug Release RelWithDebInfo Distribution)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${CMAKE_BINARY_DIR}/bin)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${CMAKE_BINARY_DIR}/bin)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${CMAKE_BINARY_DIR}/bin)
+endforeach()
+
+# Add main projects as indivudual subdirectories as they have their own CMakeLists file. These will build in order, so engine DLL first then the app (which depends on the DLL!)
 add_subdirectory(RenderingEngine)
 add_subdirectory(EngineApplication)

--- a/AetherEngine/EngineApplication/CMakeLists.txt
+++ b/AetherEngine/EngineApplication/CMakeLists.txt
@@ -20,9 +20,10 @@ set(INCLUDE
 add_executable(AetherApp ${SRC} ${INCLUDE})
 
 # Include directories for the executable
-target_include_directories(AetherApp PRIVATE ${PROJECT_SOURCE_DIR}/include)
-target_include_directories(AetherApp PRIVATE include)
-target_include_directories(AetherApp PRIVATE include)
+target_include_directories(AetherApp PRIVATE 
+    ${PROJECT_SOURCE_DIR}/include
+    include
+)
 
 # Set source groups for VS2022 quality of life
 source_group("src" FILES ${SRC})
@@ -35,53 +36,25 @@ source_group("include" FILES ${INCLUDE})
 
 
 # Configuration compile definitions
-target_compile_definitions(AetherApp PRIVATE $<CONFIG:Debug> AETHER_DEBUG)
-target_compile_definitions(AetherApp PRIVATE $<CONFIG:Release> AETHER_RELEASE)
-target_compile_definitions(AetherApp PRIVATE $<CONFIG:Distribution> AETHER_DIST)
+target_compile_definitions(AetherApp PRIVATE
+    $<CONFIG:Debug> AETHER_DEBUG
+    $<CONFIG:Release> AETHER_RELEASE
+    $<CONFIG:RelWithDebInfo> AETHER_RELEASE_DBG_INFO
+    $<CONFIG:Distribution> AETHER_DIST
+)
 
+#if (AETHER_RELEASE OR AETHER_DIST)
 # Enable optimisations when not in debug
-if (AETHER_RELEASE OR AETHER_DIST)
-        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message("Setting optimisation flags")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 endif()
 
 
 # Also explicitly add the DLL as dependency - this ensures that when running the exe, the DLL gets recompiled too :)
 add_dependencies(AetherApp AetherRenderer)
+# Also add the deploy target! This ensures the command that copies the files happens every time!
+add_dependencies(AetherApp deploy_shaders)
 
 # Link renderer DLL to our app exe
 target_link_libraries(AetherApp PRIVATE AetherRenderer)
-
-# Pre-build step to ensure that the dll is up to date!
-add_custom_command(TARGET AetherApp PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target AetherRenderer
-    COMMENT "Building engine Dll before running app .exe!"
-)
-message(STATUS "DLL Built")
-
-# Post-build step to copy the DLL to the directory where the .exe is - huge time saver!
-add_custom_command(TARGET AetherApp POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-        $<TARGET_FILE:AetherRenderer>               # The path to the generated .dll
-        $<TARGET_FILE_DIR:AetherApp>                # The directory where the .exe is located
-   COMMAND ${CMAKE_COMMAND} -E copy                 # Copy .PDB also!
-        $<TARGET_PDB_FILE:AetherRenderer>
-        $<TARGET_FILE_DIR:AetherApp>
-)       
-
-# Also copy both raw and compiled shaders!
-get_property(cso_files GLOBAL PROPERTY CSO_FILES)
-get_property(raw_shaders GLOBAL PROPERTY SHADER_FILES)
-
-set(DEST_DIR "$<TARGET_FILE_DIR:AetherApp>/Shaders")
-
-add_custom_command(TARGET AetherApp POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${DEST_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${cso_files}               
-        ${DEST_DIR}
-        COMMAND_EXPAND_LISTS
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${raw_shaders}               
-        ${DEST_DIR}
-        COMMAND_EXPAND_LISTS
-)

--- a/AetherEngine/RenderingEngine/CMakeLists.txt
+++ b/AetherEngine/RenderingEngine/CMakeLists.txt
@@ -24,21 +24,24 @@ set(INCLUDE
     Core/include/Core.h
     Core/include/CoreApp.h
     Core/include/AetherUtils.h
-    Core/include/IRenderer.h
-    Core/include/IWindow.h
     Core/include/Log.h
 
+    # Interfaces
+    Core/include/IRenderer.h
+    Core/include/IWindow.h
+
+    # Window
     GLFW/include/WinManGLFW.h
 
-    # Renderers
+    # Rendering
     EngineD3D/include/D3DUtils.h
     EngineD3D/include/RendererDX11.h
+    EngineD3D/include/RendererDX12.h
 
     Events/include/Event.h
     Events/include/KeyEvent.h
     Events/include/MouseEvent.h
     Events/include/AppEvent.h
-    EngineD3D/include/RendererDX12.h
 
 
     # Third party includes
@@ -66,15 +69,16 @@ if (MSVC)  # Check if we're on Visual Studio
 endif()
 
 # Include directories for the DLL
-target_include_directories(AetherRenderer PRIVATE ${PROJECT_SOURCE_DIR}/include)
-target_include_directories(AetherRenderer PRIVATE include)
-target_include_directories(AetherRenderer PRIVATE EngineD3D/include)
-target_include_directories(AetherRenderer PRIVATE GLFW/include)
-target_include_directories(AetherRenderer PRIVATE Events/include)
-target_include_directories(AetherRenderer PRIVATE ThirdParty/dx12Helper/include)
-
-# Public so application can see it
-target_include_directories(AetherRenderer PUBLIC Core/include)
+target_include_directories(AetherRenderer
+                    PRIVATE 
+                            ${PROJECT_SOURCE_DIR}/include
+                            EngineD3D/include
+                            GLFW/include
+                            Events/include
+                            ThirdParty/dx12Helper/include
+                    PUBLIC
+                         Core/include # Public as application target needs to see it too
+)
 
 
 # Set source groups for VS2022 quality of life
@@ -100,12 +104,16 @@ target_compile_definitions(AetherRenderer PRIVATE AETHER_BUILD_DLL)
 #
 
 # Configuration compile definitions
-target_compile_definitions(AetherRenderer PRIVATE $<CONFIG:Debug> AETHER_DEBUG)
-target_compile_definitions(AetherRenderer PRIVATE $<CONFIG:Release> AETHER_RELEASE)
-target_compile_definitions(AetherRenderer PRIVATE $<CONFIG:Distribution> AETHER_DIST)
+target_compile_definitions(AetherRenderer PRIVATE 
+    $<CONFIG:Debug> AETHER_DEBUG
+    $<CONFIG:Release> AETHER_RELEASE
+    $<CONFIG:RelWithDebInfo> AETHER_RELEASE_DBG_INFO
+    $<CONFIG:Distribution> AETHER_DIST
+)
 
 # Enable optimisations when not in debug
-if (AETHER_RELEASE OR AETHER_DIST)
+#if (AETHER_RELEASE OR AETHER_DIST)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug" )
         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 endif()
 
@@ -189,29 +197,38 @@ foreach(FILE ${HLSL_SHADER_FILES})
     
     get_source_file_property(shadertype ${FILE} ShaderType)
     get_source_file_property(shadermodel ${FILE} ShaderModel)
-
-    add_custom_command(TARGET AetherRenderer PRE_LINK
-                       COMMAND dxc.exe /nologo /E main /T ${shadertype}_${shadermodel} /Od /Zi /Fo ${CMAKE_CURRENT_BINARY_DIR}/${FILE_WE}.cso /Fd ${CMAKE_CURRENT_BINARY_DIR}/${FILE_WE}.pdb ${FILE}
-                       COMMENT "HLSL ${FILE}"
-                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                       VERBATIM)
+                      
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${FILE_WE}.cso
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND dxc.exe /nologo /E main /T ${shadertype}_${shadermodel}
+                /Od /Zi /Fo ${CMAKE_CURRENT_BINARY_DIR}/${FILE_WE}.cso 
+                /Fd ${CMAKE_CURRENT_BINARY_DIR}/${FILE_WE}.pdb ${FILE}
+        DEPENDS ${FILE}
+        COMMENT "Compiling HLSL ${FILE}..."
+        COMMAND ${CMAKE_COMMAND} -E echo "Successfuly compiled shader!"
+        VERBATIM
+    )
 endforeach(FILE)
 
-# Make raw shader and CSO list public and visible to our EXE so that it can copy it post-build
-set_property(GLOBAL PROPERTY SHADER_FILES "${RAW_SHADER_FILES}")
-set_property(GLOBAL PROPERTY CSO_FILES "${CSO_SHADER_FILES}")
 
-# Copy CSOs to DLL folder in build step
-add_custom_command(TARGET AetherRenderer POST_BUILD
-                  COMMAND ${CMAKE_COMMAND} -E copy ${CSO_SHADER_FILES} $<TARGET_FILE_DIR:AetherRenderer>
-                  COMMAND_EXPAND_LISTS
-)
+# Create a target for shaders - using snake_case to denote that this is an intermediate target only
+add_custom_target(aether_shaders DEPENDS ${CSO_SHADER_FILES})
 
-set(DEST_DIR "$<TARGET_FILE_DIR:AetherRenderer>/Shaders")
-add_custom_command(TARGET AetherRenderer POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${DEST_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${RAW_SHADER_FILES}               
-        ${DEST_DIR}
-        COMMAND_EXPAND_LISTS
+# Make renderer depend on shader compilation
+add_dependencies(AetherRenderer aether_shaders)
+
+# Deployment target (DLL + PDB + shaders)
+set(RUNTIME_DIR "$<TARGET_FILE_DIR:AetherRenderer>")
+set(SHADER_DEST "${RUNTIME_DIR}/Shaders")
+
+
+# Copy raw shaders and CSOs to bin folder in build step via another custom intermediate target
+add_custom_target(deploy_shaders ALL
+    DEPENDS AetherRenderer aether_shaders
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${SHADER_DEST}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CSO_SHADER_FILES} ${SHADER_DEST} COMMAND_EXPAND_LISTS
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${RAW_SHADER_FILES} ${SHADER_DEST} COMMAND_EXPAND_LISTS
+    COMMENT "Deploying AetherEngine shaders..."
+    COMMAND ${CMAKE_COMMAND} -E echo "Engine shader files deployed!"
 )

--- a/AetherEngine/RenderingEngine/CMakeLists.txt
+++ b/AetherEngine/RenderingEngine/CMakeLists.txt
@@ -86,9 +86,18 @@ source_group("src" FILES ${SRC})
 source_group("include" FILES ${INCLUDE})
 source_group("shaders" FILES ${HLSL_SHADER_FILES})
 
-# Third-party subdirectories
-add_subdirectory(ThirdParty/glfw)
-add_subdirectory(ThirdParty/spdlog)
+#
+# Third-party libraries and subdirectories
+#
+
+if(USE_GLFW)
+    add_subdirectory(ThirdParty/glfw EXCLUDE_FROM_ALL)  # EXCLUDE ensures we only build this subdirectory once!
+    target_link_libraries(AetherRenderer PRIVATE glfw)
+    # Set pre-processor macro in target
+    target_compile_definitions(AetherRenderer PRIVATE USE_GLFW)
+endif()
+
+add_subdirectory(ThirdParty/spdlog EXCLUDE_FROM_ALL)
 
 # Link third party modules to renderer
 target_link_libraries(AetherRenderer PRIVATE glfw)
@@ -131,12 +140,6 @@ if(WIN32)
     target_compile_definitions(AetherRenderer PUBLIC AETHER_PLATFORM_WINDOWS)
     target_compile_definitions(AetherRenderer PRIVATE USE_WIN32)
 endif()
-
-if(USE_GLFW)
-    # Set pre-processor macros
-    target_compile_definitions(AetherRenderer PRIVATE USE_GLFW)
-endif()
-
 
 
 #

--- a/AetherEngine/RenderingEngine/CMakeLists.txt
+++ b/AetherEngine/RenderingEngine/CMakeLists.txt
@@ -104,7 +104,7 @@ target_link_libraries(AetherRenderer PRIVATE glfw)
 target_link_libraries(AetherRenderer PUBLIC spdlog::spdlog_header_only)
 
 
-# Define macro to ensure this project exports a DLL - this is how games can function as their own apps using our rendering code
+# Define macro to ensure this project exports a DLL - this will be undefined in the application and so will importing our DLL instead! See Core.h for implementation of this
 target_compile_definitions(AetherRenderer PRIVATE AETHER_BUILD_DLL)
 
 


### PR DESCRIPTION
Things just work now! (Todd Howard - 2016)

+ Setup new dedicated binary folder at top-level of CMakeLists
+ DLL no longer needs copying, it is output directly next to the DLL
+ Same goes for PDB file

- Remove all "PRE/POST-LINK/BUILD" custom commands
+ Replace these with "OUTPUT" commands that are more predictable and reliable

+ Improved shader compile step significantly
+ Dedicated intermediate target that correctly copies the Shader files!

+ General cleanup and removal of redundant lines