### PR TITLE
Feature - ImGui Docking and Viewports

### DIFF
--- a/AetherEngine/RenderingEngine/Core/include/CoreApp.h
+++ b/AetherEngine/RenderingEngine/Core/include/CoreApp.h
@@ -42,7 +42,7 @@ namespace Aether
 		std::unique_ptr<IWindow> m_Window;
 		std::unique_ptr<IRenderer> m_Renderer;
 
-		//std::unique_ptr<ImGuiLayer> m_ImGuiLayer;
+		// Layers all get owned by the layer stack, so we can create this as a raw pointer
 		ImGuiLayer* m_ImGuiLayer = nullptr;
 
 		LayerStack m_LayerStack;

--- a/AetherEngine/RenderingEngine/Core/include/IRenderer.h
+++ b/AetherEngine/RenderingEngine/Core/include/IRenderer.h
@@ -16,6 +16,7 @@ namespace Aether
         virtual AETHER_RESULT Initialize(IWindow& window) = 0;
         virtual void ClearFrame() = 0;
         virtual void Render() = 0;
+        virtual void Present() = 0;
         virtual void Resize(int newWidth, int newHeight) = 0;
         virtual void Terminate() = 0;
         virtual void* GetNativeDevice() = 0;
@@ -23,7 +24,8 @@ namespace Aether
 
         // To be called by ImGui layer
         virtual void InitImGui() = 0;
-        virtual void RenderImGui() = 0;
+        virtual void BeginImGuiRender() = 0;
+        virtual void EndImGuiRender() = 0;
     };
 
     enum class eRenderAPI

--- a/AetherEngine/RenderingEngine/Core/src/CoreApp.cpp
+++ b/AetherEngine/RenderingEngine/Core/src/CoreApp.cpp
@@ -151,11 +151,20 @@ namespace Aether
             // Handle window events here (e.g., using GLFW or another windowing library)
             m_Window->PollEvents();
 
-            // Update our layers! Eventually, the renderer will tie in to this aswell as it will render each layer. ImGui renders here too, which is why clear frame earlier!
+            // Refresh ImGui drawing context
+            m_ImGuiLayer->Begin();
+
+            // Update our layers! Eventually, the renderer will tie in to this aswell as it will render each layer. ImGui renders here too, which is why we clear frame and begin earlier.
             m_LayerStack.UpdateLayers();
 
-            // Render our finished lovely frame!
+            // Draw anything else we want!
             m_Renderer->Render();
+
+            // Finalise ImGui drawing afterwards
+            m_ImGuiLayer->End();
+
+            // Present our finished lovely frame!
+            m_Renderer->Present();
         }
 
         printf("\n\n\n");

--- a/AetherEngine/RenderingEngine/Layers/include/ImGuiLayer.h
+++ b/AetherEngine/RenderingEngine/Layers/include/ImGuiLayer.h
@@ -35,10 +35,10 @@ namespace Aether
 		ImGuiLayer(eRenderAPI backend);
 		~ImGuiLayer();
 
-		void OnAttach();
-		void OnDetach();
-		void OnUpdate();
-		void OnEvent(Event& event);
+		void OnAttach() override;
+		void OnDetach() override;
+		void OnUpdate() override;
+		void OnEvent(Event& event) override;
 
 		void SetStyle();
 	protected:

--- a/AetherEngine/RenderingEngine/Layers/include/ImGuiLayer.h
+++ b/AetherEngine/RenderingEngine/Layers/include/ImGuiLayer.h
@@ -40,8 +40,12 @@ namespace Aether
 		void OnUpdate() override;
 		void OnEvent(Event& event) override;
 
-		void SetStyle();
+		void Begin();
+		void End();
+
 	protected:
 		eRenderAPI m_CurrentRenderAPI;
+	private:
+		void SetStyle();
 	};
 };

--- a/AetherEngine/RenderingEngine/Layers/src/ImGuiLayer.cpp
+++ b/AetherEngine/RenderingEngine/Layers/src/ImGuiLayer.cpp
@@ -57,6 +57,28 @@ namespace Aether
 
 	void ImGuiLayer::OnDetach()
 	{
+		ImGui_ImplGlfw_Shutdown();
+
+		// Make sure we shut down the right implementation!
+		switch (m_CurrentRenderAPI)
+		{
+			case eRenderAPI::kOpenGL:
+			{
+				ImGui_ImplOpenGL3_Shutdown();
+				break;
+			}
+			case eRenderAPI::kDX11:
+			{
+				ImGui_ImplDX11_Shutdown();
+				break;
+			}
+			case eRenderAPI::kDX12:
+			{
+				ImGui_ImplDX12_Shutdown();
+				break;
+			}
+		}
+		ImGui::DestroyContext();
 	}
 
 	void ImGuiLayer::OnUpdate()

--- a/AetherEngine/RenderingEngine/Layers/src/ImGuiLayer.cpp
+++ b/AetherEngine/RenderingEngine/Layers/src/ImGuiLayer.cpp
@@ -16,8 +16,8 @@ namespace Aether
 		ImGuiIO& io = ImGui::GetIO();
 		io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;			// Enable Keyboard Controls
 		//io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;			// Enable Gamepad Controls
-		//io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;				// Enable Docking
-		//io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;			// Enable Multi-Viewport / Platform Windows
+		io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;				// Enable Docking
+		io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;			// Enable Multi-Viewport / Platform Windows
 		//io.ConfigFlags |= ImGuiConfigFlags_ViewportsNoTaskBarIcons;
 		//io.ConfigFlags |= ImGuiConfigFlags_ViewportsNoMerge;
 
@@ -81,20 +81,43 @@ namespace Aether
 		ImGui::DestroyContext();
 	}
 
-	void ImGuiLayer::OnUpdate()
+	void ImGuiLayer::Begin()
 	{
-		// Setup generic drawing frame, let derived classes implement specifics after this
-		//
-
+		// Update ImGui data 
 		ImGuiIO& io = ImGui::GetIO();
 		io.DisplaySize = ImVec2((float)Application::Get().GetWindow().GetWidth(), (float)Application::Get().GetWindow().GetHeight());
 		io.DeltaTime = (float)glfwGetTime();
 
+		// Call the specific rendering API implementation to begin new frames
+		Application::Get().GetRenderer().BeginImGuiRender();
 
-		// Now proceed with specific rendering API path
-		Application::Get().GetRenderer().RenderImGui();
+		// Now call the generic new frame function once here
+		ImGui::NewFrame();
+	}
+
+	void ImGuiLayer::OnUpdate()
+	{
+		// Currently, the only thing our ImGui layer is doing is this
+		bool show = true;
+		ImGui::ShowDemoWindow(&show);
 
 	}
+
+	void ImGuiLayer::End()
+	{
+		Application::Get().GetRenderer().EndImGuiRender();
+
+		// Necessary ImGui steps when docking and viewports are enabled
+		ImGuiIO& io = ImGui::GetIO();
+		if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+		{
+			GLFWwindow* backup_current_context = glfwGetCurrentContext();
+			ImGui::UpdatePlatformWindows();
+			ImGui::RenderPlatformWindowsDefault();
+			glfwMakeContextCurrent(backup_current_context);
+		}
+	}
+
 
 	void ImGuiLayer::OnEvent(Event& event)
 	{

--- a/AetherEngine/RenderingEngine/Renderer/DirectX/include/RendererDX11.h
+++ b/AetherEngine/RenderingEngine/Renderer/DirectX/include/RendererDX11.h
@@ -14,15 +14,18 @@ namespace Aether
 	public:
 		// Main start up function
 		AETHER_RESULT Initialize(IWindow& window) override;
-		void Render() override;
-		void Resize(int newWidth, int newHeight) override;
 		void ClearFrame() override;
+		void Render() override;
+		void Present() override;
+
+		void Resize(int newWidth, int newHeight) override;
 		void Terminate() override;
 		void* GetNativeDevice() override { return m_pD3DDevice.Get(); }
 		void* GetNativeContext() override { return m_pD3DImmediateContext.Get(); }
 
 		void InitImGui() override;
-		void RenderImGui() override;
+		void BeginImGuiRender() override;
+		void EndImGuiRender() override;
 
 		// Default minimum behaviour when ALT+ENTER or drag or resize
 		// Parameters are new width and height of window

--- a/AetherEngine/RenderingEngine/Renderer/DirectX/include/RendererDX12.h
+++ b/AetherEngine/RenderingEngine/Renderer/DirectX/include/RendererDX12.h
@@ -16,13 +16,16 @@ namespace Aether
 		AETHER_RESULT Initialize(IWindow& window) override;
 		void ClearFrame() override;
 		void Render() override;
+		void Present() override;
+
 		void Resize(int newWidth, int newHeight) override;
 		void Terminate() override;
 		void* GetNativeDevice() override { return m_Device.Get(); }
 		void* GetNativeContext() override { return 0; }
 
 		void InitImGui() override;
-		void RenderImGui() override;
+		void BeginImGuiRender() override;
+		void EndImGuiRender() override;
 
 		// Public accessors
 		//

--- a/AetherEngine/RenderingEngine/Renderer/DirectX/src/RendererDX11.cpp
+++ b/AetherEngine/RenderingEngine/Renderer/DirectX/src/RendererDX11.cpp
@@ -41,8 +41,10 @@ namespace Aether
 	}
 
 	void RendererDX11::Render()
+	{} // Currently not rendering any geometry
+
+	void RendererDX11::Present()
 	{
-		// Present the frame
 		m_pSwapChain->Present(1, 0);
 	}
 
@@ -90,20 +92,17 @@ namespace Aether
 		ImGui_ImplDX11_Init(m_pD3DDevice.Get(), m_pD3DImmediateContext.Get());
 	}
 
-	void RendererDX11::RenderImGui()
+	void RendererDX11::BeginImGuiRender()
 	{
-
 		ImGui_ImplDX11_NewFrame();
 		ImGui_ImplGlfw_NewFrame();
-		ImGui::NewFrame();
+	}
 
-		bool show = true;
-		ImGui::ShowDemoWindow(&show);
-
+	void RendererDX11::EndImGuiRender()
+	{
 		ImGui::Render();
 		ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 	}
-
 
 	bool RendererDX11::CreateDevice()
 	{

--- a/AetherEngine/RenderingEngine/Renderer/DirectX/src/RendererDX12.cpp
+++ b/AetherEngine/RenderingEngine/Renderer/DirectX/src/RendererDX12.cpp
@@ -160,40 +160,39 @@ namespace Aether
 		ImGui_ImplDX12_Init(&init_info);
 	}
 
-	void RendererDX12::RenderImGui()
+	void RendererDX12::BeginImGuiRender()
 	{
 		ImGui_ImplDX12_NewFrame();
 		ImGui_ImplGlfw_NewFrame();
-		ImGui::NewFrame();
+	}
 
-		bool show = true;
-		ImGui::ShowDemoWindow(&show);
-
+	void RendererDX12::EndImGuiRender()
+	{
 		ImGui::Render();
 		ID3D12DescriptorHeap* pSrvHeaps[] = { m_SRVHeap.Get() };
 		m_CmdList->SetDescriptorHeaps(1, pSrvHeaps);
-	}
 
+		// Render ImGui on top of everything else!
+		ImGui_ImplDX12_RenderDrawData(ImGui::GetDrawData(), m_CmdList.Get());
+	}
 	void RendererDX12::Render()
 	{
 		AETHER_RESULT ar = AETHER_OK;
 
-		// Draw something! Simple triangle for now
-
-		// draw triangle
+		// Draw something! Simple depth tested quads for now
 		m_CmdList->SetGraphicsRootSignature(m_RootSig);                             // Set the root signature
 		m_CmdList->RSSetViewports(1, &m_Viewport);                                  // Set the viewports
 		m_CmdList->RSSetScissorRects(1, &m_Scissor);                                // Set the scissor rects
 		m_CmdList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);     // Set the primitive topology
 		m_CmdList->IASetVertexBuffers(0, 1, &m_VertBufView);                        // Set the vertex buffer (using the vertex buffer view)
-		// m_CmdList->DrawInstanced(3, 1, 0, 0);                                    // Finally draw 3 vertices (draw the triangle)
 		m_CmdList->IASetIndexBuffer(&m_IdxBufView);                                 // Set IB
 		m_CmdList->DrawIndexedInstanced(6, 1, 0, 0, 0);                             // Draw 2 triangles (draw 1 instance of 2 triangles)
 		m_CmdList->DrawIndexedInstanced(6, 1, 0, 4, 0);                             // Draw second quad
 
-		// Render imGui on top of all of this!
-		ImGui_ImplDX12_RenderDrawData(ImGui::GetDrawData(), m_CmdList.Get());
+	}
 
+	void RendererDX12::Present()
+	{
 		// Now we've finished drawing, get the RT ready to present again. 
 		CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_RenderTargets[m_BackBufferIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT);
 		m_CmdList->ResourceBarrier(1, &barrier);
@@ -212,9 +211,7 @@ namespace Aether
 
 		// Signal fence for THIS CPU frame
 		m_FenceValue[m_FrameContextIndex] = ++m_GlobalFenceValue;
-		AETHER_HR_ASSERT(m_CmdQueue->Signal(m_Fence.Get(), m_FenceValue[m_FrameContextIndex]));
-
-
+		AETHER_HR_ASSERT(m_CmdQueue->Signal(m_Fence.Get(), m_FenceValue[m_FrameContextIndex]))
 	}
 
 	void RendererDX12::Resize(int newWidth, int newHeight)

--- a/AetherEngine/RenderingEngine/Renderer/OpenGL/include/RendererOpenGL.h
+++ b/AetherEngine/RenderingEngine/Renderer/OpenGL/include/RendererOpenGL.h
@@ -12,16 +12,18 @@ namespace Aether
 	public:
 		// Main start up function
 		AETHER_RESULT Initialize(IWindow& window) override;
-		void Render() override;
-		void Resize(int newWidth, int newHeight) override {}	// Empty for now since GLFW seemingly handles this for us!
 		void ClearFrame() override;
+		void Render() override;
+		void Present() override;
+
+		void Resize(int newWidth, int newHeight) override {}	// Empty for now since GLFW seemingly handles this for us!
 		void Terminate() override;
 		void* GetNativeDevice() override { return 0; }
 		void* GetNativeContext() override { return 0; }
 
 		void InitImGui() override;
-		void RenderImGui() override;
-
+		void BeginImGuiRender() override;
+		void EndImGuiRender() override;
 	private:
 		GLFWwindow* m_pWindow;
 	};

--- a/AetherEngine/RenderingEngine/Renderer/OpenGL/src/RendererOpenGL.cpp
+++ b/AetherEngine/RenderingEngine/Renderer/OpenGL/src/RendererOpenGL.cpp
@@ -16,6 +16,9 @@ AETHER_RESULT Aether::RendererOpenGL::Initialize(IWindow& window)
 }
 
 void Aether::RendererOpenGL::Render()
+{} // Currently not rendering anything!
+
+void Aether::RendererOpenGL::Present()
 {
 	glfwSwapBuffers(m_pWindow);
 }
@@ -35,15 +38,14 @@ void Aether::RendererOpenGL::InitImGui()
 	ImGui_ImplOpenGL3_Init("#version 410");
 }
 
-void Aether::RendererOpenGL::RenderImGui()
+void Aether::RendererOpenGL::BeginImGuiRender()
 {
 	ImGui_ImplOpenGL3_NewFrame();
 	ImGui_ImplGlfw_NewFrame();
-	ImGui::NewFrame();
+}
 
-	bool show = true;
-	ImGui::ShowDemoWindow(&show);
-
+void Aether::RendererOpenGL::EndImGuiRender()
+{
 	ImGui::Render();
 	ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 }

--- a/AetherEngine/RenderingEngine/Window/src/WindowGLFW.cpp
+++ b/AetherEngine/RenderingEngine/Window/src/WindowGLFW.cpp
@@ -47,8 +47,9 @@ namespace Aether
 
             s_bInitGLFW = true;
         }
+
         // Create a GLFW window without an OpenGL context
-       // glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+        // glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
        
         // VSync
         //glfwSwapInterval(1);


### PR DESCRIPTION
We got dockspace and imgui windows that can leave our main render window / viewport!

Also:
 + Separated rendering of ImGui into cleaner begin/end pattern
 + Render APIs themselves are separated into clear/present)so that we can ensure ImGui gets drawn last right before we present the frame
 + Moving the actual choice of what gets drawn (showing windows etc) to the layer itself. Currently just sits in the base ImGuiLayer class update function